### PR TITLE
fix: use correct default port for sftp

### DIFF
--- a/.vscode/sftp.json
+++ b/.vscode/sftp.json
@@ -1,6 +1,6 @@
 {
     "host": "",          // Sunucu adresi
-    "port": 21,                     // FTP portu (varsayılan: 21)
+    "port": 22,                     // SFTP portu (varsayılan: 22)
     "username": "",      // FTP kullanıcı adı
     "password": "",        // FTP şifresi
     "protocol": "sftp",              // Protokol (FTP kullanıyorsunuz)


### PR DESCRIPTION
## Summary
- fix the port setting in `.vscode/sftp.json` to use 22
- update the comment to show the default port for SFTP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f879021288332a32f79d5475301f4